### PR TITLE
Remove subtasks field from frontend UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A lightweight task and event capture application with persistent cloud storage. 
 - **Event Tracking**: Schedule events with start times, durations, locations, and attendees
 - **Natural Language Parsing**: Quick entry with phrases like "Draft proposal by Friday 2h hard #work"
 - **Tags & Organization**: Tag items and filter by categories
-- **Rich Metadata**: Add notes, URLs, subtasks, dependencies, and recurrence patterns
+- **Rich Metadata**: Add notes, URLs, dependencies, and recurrence patterns
 - **Cross-Device Sync**: Access your data from anywhere with cloud storage
 - **Real-time Updates**: Changes sync immediately with the backend
 

--- a/frontend/src/QuickCaptureApp.tsx
+++ b/frontend/src/QuickCaptureApp.tsx
@@ -863,22 +863,6 @@ const QuickCaptureApp: React.FC = () => {
                                 className="w-full px-3 py-2 border rounded-lg"
                               />
                             </div>
-
-                            <div>
-                              <label className="block text-sm font-medium text-gray-700 mb-1">
-                                Subtasks
-                              </label>
-                              <textarea
-                                value={formData.subtasks?.join('\n') || ''}
-                                onChange={(e) => {
-                                  const lines = e.target.value.split('\n').filter(s => s.trim());
-                                  setFormData({ ...formData, subtasks: lines.length > 0 ? lines : null });
-                                }}
-                                placeholder="One subtask per line"
-                                rows={3}
-                                className="w-full px-3 py-2 border rounded-lg"
-                              />
-                            </div>
                           </>
                         ) : (
                           <>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,7 +19,6 @@ export interface Item {
   priority?: 1 | 2 | 3 | 4 | 5 | null;
   earliest_start?: string | null;
   recurrence?: string | null;
-  subtasks?: string[] | null;
   dependencies?: string[] | null;
   tags?: string[] | null;
   notes?: string | null;


### PR DESCRIPTION
## Summary
Removes the subtasks field from the frontend user interface while keeping it in the database and backend for now.

## Changes
- Removed `subtasks` field from `frontend/src/types.ts` Item interface
- Removed subtasks textarea UI from task creation/edit form in `QuickCaptureApp.tsx`
- Updated `README.md` to remove subtasks from Rich Metadata feature description

## What Stays Unchanged
- Database schema still has the `subtasks` column
- Backend types still include the `subtasks` field to match the database

## Testing
- ✅ Frontend builds successfully with no TypeScript errors
- ✅ Verified subtasks input is removed from the UI
- ✅ Other task fields still work correctly

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)